### PR TITLE
Settings: Whitelist WRITE_DEVICE_CONFIG permission

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -60,6 +60,7 @@
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.READ_DEVICE_CONFIG" />
+    <uses-permission android:name="android.permission.WRITE_DEVICE_CONFIG" />
     <uses-permission android:name="android.permission.STATUS_BAR" />
     <uses-permission android:name="android.permission.MANAGE_USB" />
     <uses-permission android:name="android.permission.MANAGE_DEBUGGING" />


### PR DESCRIPTION
* needed after r30 merge

log:-

13:23:56.691  1422  2892 E DatabaseUtils: java.lang.SecurityException: Permission denial: writing to settings requires:android.permission.WRITE_DEVICE_CONFIG
02-02 13:23:56.691  1422  2892 E DatabaseUtils: 	at com.android.providers.settings.SettingsProvider.enforceWritePermission(SettingsProvider.java:2065)
02-02 13:23:56.691  1422  2892 E DatabaseUtils: 	at com.android.providers.settings.SettingsProvider.setAllConfigSettings(SettingsProvider.java:1090)
02-02 13:23:56.691  1422  2892 E DatabaseUtils: 	at com.android.providers.settings.SettingsProvider.call(SettingsProvider.java:422)
02-02 13:23:56.691  1422  2892 E DatabaseUtils: 	at android.content.ContentProvider.call(ContentProvider.java:2448)
02-02 13:23:56.691  1422  2892 E DatabaseUtils: 	at android.content.ContentProvider$Transport.call(ContentProvider.java:517)
02-02 13:23:56.691  1422  2892 E DatabaseUtils: 	at android.content.ContentProviderNative.onTransact(ContentProviderNative.java:295)
02-02 13:23:56.691  1422  2892 E DatabaseUtils: 	at android.os.Binder.execTransactInternal(Binder.java:1154)
02-02 13:23:56.691  1422  2892 E DatabaseUtils: 	at android.os.Binder.execTransact(Binder.java:1123)
02-02 13:23:56.691  1099  4392 E Utils   : did not find channel-count and/or sample-rate

Signed-off-by: saikiran2001 <bjsaikiran@gmail.com>