### PR TITLE
A2dpSrc: DEV-UI support for Blutooth Audio codec.

### DIFF
--- a/res/layout/bluetooth_audio_codec_dialog.xml
+++ b/res/layout/bluetooth_audio_codec_dialog.xml
@@ -52,7 +52,15 @@
                 layout="@layout/preference_widget_dialog_radiobutton"/>
 
             <include
+                android:id="@+id/bluetooth_audio_codec_aptx_adaptive"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
                 android:id="@+id/bluetooth_audio_codec_ldac"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
+                android:id="@+id/bluetooth_audio_codec_aptx_twsp"
                 layout="@layout/preference_widget_dialog_radiobutton"/>
         </RadioGroup>
 

--- a/src/com/android/settings/development/bluetooth/AbstractBluetoothDialogPreferenceController.java
+++ b/src/com/android/settings/development/bluetooth/AbstractBluetoothDialogPreferenceController.java
@@ -38,7 +38,9 @@ public abstract class AbstractBluetoothDialogPreferenceController extends
 
     private static final String TAG = "AbstractBtDlgCtr";
 
-    protected static final int[] CODEC_TYPES = {BluetoothCodecConfig.SOURCE_CODEC_TYPE_LDAC,
+    protected static final int[] CODEC_TYPES = {BluetoothCodecConfig.SOURCE_CODEC_TYPE_APTX_TWSP,
+            BluetoothCodecConfig.SOURCE_CODEC_TYPE_LDAC,
+            BluetoothCodecConfig.SOURCE_CODEC_TYPE_APTX_ADAPTIVE,
             BluetoothCodecConfig.SOURCE_CODEC_TYPE_APTX_HD,
             BluetoothCodecConfig.SOURCE_CODEC_TYPE_APTX,
             BluetoothCodecConfig.SOURCE_CODEC_TYPE_AAC,
@@ -225,6 +227,7 @@ public abstract class AbstractBluetoothDialogPreferenceController extends
             Log.d(TAG, "Unable to get highest codec. Configs are empty");
             return BluetoothCodecConfig.SOURCE_CODEC_TYPE_INVALID;
         }
+        Log.d(TAG, "CODEC_TYPES len: " + CODEC_TYPES.length + " codec_config len: " + configs.length);
         for (int i = 0; i < CODEC_TYPES.length; i++) {
             for (int j = 0; j < configs.length; j++) {
                 if ((configs[j].getCodecType() == CODEC_TYPES[i])) {

--- a/src/com/android/settings/development/bluetooth/BluetoothCodecDialogPreference.java
+++ b/src/com/android/settings/development/bluetooth/BluetoothCodecDialogPreference.java
@@ -22,11 +22,15 @@ import android.widget.RadioGroup;
 
 import com.android.settings.R;
 
+import android.util.Log;
+
 /**
  * Dialog preference to set the Bluetooth A2DP config of codec
  */
 public class BluetoothCodecDialogPreference extends BaseBluetoothDialogPreference implements
         RadioGroup.OnCheckedChangeListener {
+
+    private static final String TAG = "BtCodecDlgPref";
 
     public BluetoothCodecDialogPreference(Context context) {
         super(context);
@@ -60,13 +64,19 @@ public class BluetoothCodecDialogPreference extends BaseBluetoothDialogPreferenc
         mRadioButtonIds.add(R.id.bluetooth_audio_codec_aac);
         mRadioButtonIds.add(R.id.bluetooth_audio_codec_aptx);
         mRadioButtonIds.add(R.id.bluetooth_audio_codec_aptx_hd);
+        mRadioButtonIds.add(R.id.bluetooth_audio_codec_aptx_adaptive);
         mRadioButtonIds.add(R.id.bluetooth_audio_codec_ldac);
+        mRadioButtonIds.add(R.id.bluetooth_audio_codec_aptx_twsp);
         String[] stringArray = context.getResources().getStringArray(
                 R.array.bluetooth_a2dp_codec_titles);
+
+        Log.e(TAG, "a2dp_codec_titles array length: " + stringArray.length);
         for (int i = 0; i < stringArray.length; i++) {
             mRadioButtonStrings.add(stringArray[i]);
         }
+
         stringArray = context.getResources().getStringArray(R.array.bluetooth_a2dp_codec_summaries);
+        Log.e(TAG, "a2dp_codec_summaries array length: " + stringArray.length);
         for (int i = 0; i < stringArray.length; i++) {
             mSummaryStrings.add(stringArray[i]);
         }


### PR DESCRIPTION
Due to enhancements in the DEV-UI by AOSP, Blutooth Audio
codec menu showing nothing in developer settings. Due to
length mismatch of the bluetooth_a2dp_codec_titles and
bluetooth_a2dp_codec_summaries in settings leading to
this issue.

Issue has been fixed by introducing QVA codecs too, so
that length won't mismatch.

CRs-Fixed: 2624640
Change-Id: I849e340152be5043782fa8274636a534c147c8bb