### PR TITLE
Show Android version as 12L

### DIFF
--- a/src/com/android/settings/deviceinfo/firmwareversion/FirmwareVersionDetailPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/firmwareversion/FirmwareVersionDetailPreferenceController.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.SystemClock;
 import android.os.UserHandle;
+import android.os.SystemProperties;
 import android.os.UserManager;
 import android.text.TextUtils;
 import android.util.Log;
@@ -36,6 +37,9 @@ import com.android.settingslib.RestrictedLockUtils;
 import com.android.settingslib.RestrictedLockUtilsInternal;
 
 public class FirmwareVersionDetailPreferenceController extends BasePreferenceController {
+
+    @VisibleForTesting
+    private static final String PLATFORM_RELEASE_OR_CODENAME = "ro.spark.settings.android_version";
 
     private static final String TAG = "firmwareDialogCtrl";
     private static final int DELAY_TIMER_MILLIS = 500;
@@ -75,7 +79,8 @@ public class FirmwareVersionDetailPreferenceController extends BasePreferenceCon
 
     @Override
     public CharSequence getSummary() {
-        return Build.VERSION.RELEASE_OR_CODENAME;
+        return SystemProperties.get(PLATFORM_RELEASE_OR_CODENAME, 
+            Build.VERSION.RELEASE_OR_CODENAME);
     }
 
     @Override

--- a/src/com/android/settings/deviceinfo/firmwareversion/FirmwareVersionPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/firmwareversion/FirmwareVersionPreferenceController.java
@@ -16,12 +16,18 @@
 
 package com.android.settings.deviceinfo.firmwareversion;
 
-import android.content.Context;
 import android.os.Build;
+import android.content.Context;
+import android.os.SystemProperties;
+import androidx.annotation.VisibleForTesting;
 
+import com.android.settings.R;
 import com.android.settings.core.BasePreferenceController;
 
 public class FirmwareVersionPreferenceController extends BasePreferenceController {
+
+    @VisibleForTesting
+    private static final String PLATFORM_RELEASE_OR_CODENAME = "ro.spark.settings.android_version";
 
     public FirmwareVersionPreferenceController(Context context, String key) {
         super(context, key);
@@ -34,6 +40,7 @@ public class FirmwareVersionPreferenceController extends BasePreferenceControlle
 
     @Override
     public CharSequence getSummary() {
-        return Build.VERSION.RELEASE_OR_CODENAME;
+        return SystemProperties.get(PLATFORM_RELEASE_OR_CODENAME, 
+            Build.VERSION.RELEASE_OR_CODENAME);
     }
 }


### PR DESCRIPTION
- @techyminati :
   * Android 12 & 12L, Both Show Platform version as "12", while 12L is not a QPR release , its a Android Bump
  ( Android 12 = VNDK31, Android 12.1/12L = VNDK 32 ), Even Google released the newer tags with android-12.1.0_r1 ,
   not with android-12.0.0 branding [1], Some end users do not know if they're running Android 12 or 12L, this's because
   Android Version Being displayed as "12" on both 12 & 12L, Even Google Docs [2] refer the newer Android Version as 12L,
   I've no idea why they didnt care to bump it here, hence refactor PLATFORM_VERSION_LAST_STABLE to 12L

[1] - https://android.googlesource.com/platform/manifest/+/refs/tags/android-12.1.0_r1
[2] - https://developer.android.com/about/versions/12/12L/summary

Change-Id: I12420d61c8564b833466f739eb87d20cfc651f
Signed-off-by: Aryan Sinha <sinha.aryan03@gmail.com>