### PR TITLE
Settings: Fix loading iconpack-based Wellbeing icon

### DIFF
--- a/src/com/android/settings/dashboard/DashboardFeatureProviderImpl.java
+++ b/src/com/android/settings/dashboard/DashboardFeatureProviderImpl.java
@@ -41,6 +41,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.Icon;
+import android.graphics.drawable.LayerDrawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.UserHandle;
@@ -87,6 +88,7 @@ public class DashboardFeatureProviderImpl implements DashboardFeatureProvider {
     private static final String TAG = "DashboardFeatureImpl";
     private static final String DASHBOARD_TILE_PREF_KEY_PREFIX = "dashboard_tile_pref_";
     private static final String META_DATA_KEY_INTENT_ACTION = "com.android.settings.intent.action";
+    private static final String WELLBEING_PACKAGE = "com.google.android.apps.wellbeing";
 
     protected final Context mContext;
 
@@ -430,6 +432,11 @@ public class DashboardFeatureProviderImpl implements DashboardFeatureProvider {
             return;
         }
         if (TextUtils.equals(tile.getCategory(), CategoryKey.CATEGORY_HOMEPAGE)) {
+            if (iconPackage.equals(WELLBEING_PACKAGE) && iconDrawable instanceof LayerDrawable
+                    && ((LayerDrawable) iconDrawable).getDrawable(1) != null) {
+                iconDrawable = ((LayerDrawable) iconDrawable).getDrawable(1);
+                iconDrawable.mutate();
+            }
             iconDrawable.setTint(Utils.getHomepageIconColor(preference.getContext()));
         } else if (forceRoundedIcon && !TextUtils.equals(mContext.getPackageName(), iconPackage)) {
             iconDrawable = new AdaptiveIcon(mContext, iconDrawable,


### PR DESCRIPTION
Wellbeing apk still provides Android 11 style settings icon when an icon pack is set. It consists of a layer-list with circle shape and drawable, so fetch the drawable to make it work with Android 12 settings.

Change-Id: I78be2db9dc8ca262e61fdb13b93da007c3a6eb81